### PR TITLE
Add getRemaining method

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,23 @@ t.setInterval(functionToCall, 2000);
 // "Hello world!" will be printed to the Serial every 2 seconds
 ```
 
+## getRemaining
+
+Gets the number of milliseconds remaining in a timer. Returns `0` on timer not found.
+
+#### Example:
+
+```c++
+AsyncTimer t;
+
+unsigned short timeoutId = t.setTimeout([]() {
+  Serial.println("Hello world!");
+}, 3000);
+
+// Get the remaining ms on the timer
+unsigned long remaining = t.getRemaining(timeoutId);
+```
+
 ## changeDelay(intervalOrTimeoutId, delayInMs)
 Changes the delay value of an active `intervalOrTimeout`.
 
@@ -276,24 +293,6 @@ t.setTimeout([]() {
 
 // After this call, only intervals will be running inside AsyncTimer
 t.cancelAll(false);
-```
-
-## getRemaining
-
-Gets the number of milliseconds remaining in a timer.  Returns -1 on timer not found.
-
-#### Example:
-
-```c++
-AsyncTimer t;
-
-// This timeout will never run
-unsigned short timeoutId = t.setTimeout([]() {
-  Serial.println("Hello world!");
-}, 3000);
-
-// Get the remaining ms on the timer
-unsigned long remaining = t.getRemaining(timeoutId);
 ```
 
 # Limitations

--- a/README.md
+++ b/README.md
@@ -123,9 +123,11 @@ t.setInterval(functionToCall, 2000);
 // "Hello world!" will be printed to the Serial every 2 seconds
 ```
 
-## getRemaining
+## getRemaining(intervalOrTimeoutId)
 
-Gets the number of milliseconds remaining in a timer. Returns `0` on timer not found.
+Gets the number of milliseconds remaining in a timer. Returns `0` if the timer is not found.
+
+`getRemaining` takes one argument, the `id` returned from `setTimeout` or `setInterval` function, returns `unsigned long`.
 
 #### Example:
 

--- a/README.md
+++ b/README.md
@@ -278,6 +278,24 @@ t.setTimeout([]() {
 t.cancelAll(false);
 ```
 
+## getRemaining
+
+Gets the number of milliseconds remaining in a timer.  Returns -1 on timer not found.
+
+#### Example:
+
+```c++
+AsyncTimer t;
+
+// This timeout will never run
+unsigned short timeoutId = t.setTimeout([]() {
+  Serial.println("Hello world!");
+}, 3000);
+
+// Get the remaining ms on the timer
+unsigned long remaining = t.getRemaining(timeoutId);
+```
+
 # Limitations
 - Capturing lambda functions do not work.
 

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "AsyncTimer",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "description": "JavaScript-like async timing functions (setTimeout, setInterval).",
   "keywords": [
     "settimeout",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=AsyncTimer
-version=2.2.3
+version=2.3.0
 author=Aasim-A
 maintainer=Aasim-A <github.com/Aasim-A>
 sentence=JavaScript-like async timing functions (setTimeout, setInterval).

--- a/src/AsyncTimer.cpp
+++ b/src/AsyncTimer.cpp
@@ -73,6 +73,14 @@ void AsyncTimer::cancelAll(bool includeIntervals) {
   }
 }
 
+unsigned long AsyncTimer::getRemaining(unsigned short id) {
+  unsigned long now = millis();
+  for (unsigned short i = 0; i < m_maxArrayLength; i++)
+    if (m_callsArray[i].id == id)
+      return m_callsArray[i].timestamp + m_callsArray[i].delayByMs - now;
+  return -1;
+}
+
 void AsyncTimer::handle() {
   if (m_arrayLength == 0)
     return;

--- a/src/AsyncTimer.cpp
+++ b/src/AsyncTimer.cpp
@@ -37,6 +37,22 @@ unsigned short AsyncTimer::setInterval(void (*callback)(), unsigned long ms) {
   return m_newTimerInfo(callback, ms, true);
 }
 
+unsigned long AsyncTimer::getRemaining(unsigned short id) {
+  unsigned long now = millis();
+  for (unsigned short i = 0; i < m_maxArrayLength; i++) {
+    if (m_callsArray[i].id == id) {
+      unsigned long tsDelay = m_callsArray[i].timestamp + m_callsArray[i].delayByMs;
+      // now can be bigger than timestamp + delayByMs because the code so far
+      // has beeen executing synchronously long enough that the library hasn't
+      // executed the callback yet
+      if (now > tsDelay)
+        return 0;
+      return tsDelay - now;
+    }
+  }
+  return 0;
+}
+
 void AsyncTimer::changeDelay(unsigned short id, unsigned long ms) {
   for (unsigned short i = 0; i < m_maxArrayLength; i++)
     if (m_callsArray[i].id == id)
@@ -71,14 +87,6 @@ void AsyncTimer::cancelAll(bool includeIntervals) {
     } else
       m_cancelEntry(i);
   }
-}
-
-unsigned long AsyncTimer::getRemaining(unsigned short id) {
-  unsigned long now = millis();
-  for (unsigned short i = 0; i < m_maxArrayLength; i++)
-    if (m_callsArray[i].id == id)
-      return m_callsArray[i].timestamp + m_callsArray[i].delayByMs - now;
-  return -1;
 }
 
 void AsyncTimer::handle() {

--- a/src/AsyncTimer.cpp
+++ b/src/AsyncTimer.cpp
@@ -43,11 +43,10 @@ unsigned long AsyncTimer::getRemaining(unsigned short id) {
     if (m_callsArray[i].id == id) {
       unsigned long tsDelay = m_callsArray[i].timestamp + m_callsArray[i].delayByMs;
       // now can be bigger than timestamp + delayByMs because the code so far
-      // has beeen executing synchronously long enough that the library hasn't
-      // executed the callback yet
-      if (now > tsDelay)
-        return 0;
-      return tsDelay - now;
+      // has beeen executing synchronously
+      if (now < tsDelay)
+        return tsDelay - now;
+      break;
     }
   }
   return 0;

--- a/src/AsyncTimer.h
+++ b/src/AsyncTimer.h
@@ -70,6 +70,7 @@ public:
   void reset(unsigned short id);
   void cancel(unsigned short id);
   void cancelAll(bool includeIntervals = true);
+  unsigned long getRemaining(unsigned short id);
   void handle();
 };
 

--- a/src/AsyncTimer.h
+++ b/src/AsyncTimer.h
@@ -65,12 +65,12 @@ public:
   setup();
   unsigned short setTimeout(void (*callback)(), unsigned long ms);
   unsigned short setInterval(void (*callback)(), unsigned long ms);
+  unsigned long getRemaining(unsigned short id);
   void changeDelay(unsigned short id, unsigned long ms);
   void delay(unsigned short id, unsigned long ms);
   void reset(unsigned short id);
   void cancel(unsigned short id);
   void cancelAll(bool includeIntervals = true);
-  unsigned long getRemaining(unsigned short id);
   void handle();
 };
 


### PR DESCRIPTION
This addresses feature request #17 

I want to be able to report how much time is left to the next interval on a timer.  I would like to write code

```c++
unsigned long remaining = t.getRemaining(timerId);
Serial.print("Time remaining: ");
Serial.println(remaining);
```

If you're okay with the code, would you like me to add in a version bump to 2.3.0?