### PR TITLE
Allow environment capture in lambda callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ unsigned short intervalId = t.setInterval([]() {
   Serial.println("Hello world!");
 }, 2000);
 
-t.setTimeout([]() {
+t.setTimeout([=]() {
   t.changeDelay(intervalId, 3500);
   // Now the interval runs every 3500ms instead of the old 2000ms
 }, 7000);
@@ -184,7 +184,7 @@ unsigned short intervalId = t.setInterval([]() {
   Serial.println("Hello world!");
 }, 2000);
 
-t.setTimeout([]() {
+t.setTimeout([=]() {
   t.delay(intervalId, 3500);
   // Now the interval will be delayed by an extra 3500ms,
   // afterwords, it will continue executing normally.
@@ -207,7 +207,7 @@ unsigned short intervalId = t.setInterval([]() {
   Serial.println("Hello world!");
 }, 2000);
 
-t.setTimeout([]() {
+t.setTimeout([=]() {
   t.reset(intervalId);
   // Now the interval will be reset, this means that it will
   // execute exactly 2000ms after the reset function call.
@@ -232,7 +232,7 @@ unsigned short intervalId = t.setInterval([]() {
 }, 2000);
 
 // Cancel the interval after 7 seconds:
-t.setTimeout([]() {
+t.setTimeout([=]() {
   t.cancel(intervalId);
 }, 7000);
 ```
@@ -300,9 +300,6 @@ t.setTimeout([]() {
 // After this call, only intervals will be running inside AsyncTimer
 t.cancelAll(false);
 ```
-
-# Limitations
-- Capturing lambda functions do not work.
 
 # Examples
 

--- a/examples/CancelInterval/CancelInterval.ino
+++ b/examples/CancelInterval/CancelInterval.ino
@@ -11,7 +11,7 @@ void setup() {
   unsigned short intervalId = t.setInterval(
       []() { digitalWrite(LED_BUILTIN, !digitalRead(LED_BUILTIN)); }, 1000);
 
-  t.setTimeout([]() { t.cancel(intervalId); }, 10000);
+  t.setTimeout([=]() { t.cancel(intervalId); }, 10000);
 }
 
 void loop() { t.handle(); }

--- a/examples/CancelTimeout/CancelTimeout.ino
+++ b/examples/CancelTimeout/CancelTimeout.ino
@@ -14,7 +14,7 @@ void setup() {
   // t.cancel(timeoutId);
 
   // Or cancel using another timeout after 3 seconds:
-  t.setTimeout([]() { t.cancel(timeoutId); }, 3000);
+  t.setTimeout([=]() { t.cancel(timeoutId); }, 3000);
 }
 
 void loop() { t.handle(); }

--- a/src/AsyncTimer.cpp
+++ b/src/AsyncTimer.cpp
@@ -13,7 +13,7 @@ unsigned short AsyncTimer::m_generateId() {
   return id;
 }
 
-unsigned short AsyncTimer::m_newTimerInfo(void (*callback)(), unsigned long ms,
+unsigned short AsyncTimer::m_newTimerInfo(Callback& callback, unsigned long ms,
                                           bool indefinite) {
   if (m_availableIndicesLength == 0 || m_arrayLength == m_maxArrayLength)
     return 0;
@@ -34,17 +34,16 @@ unsigned short AsyncTimer::m_newTimerInfo(void (*callback)(), unsigned long ms,
 
 void AsyncTimer::m_cancelEntry(unsigned short index) {
   m_callsArray[index].active = false;
-  m_callsArray[index].callback = nullptr;
   m_arrayLength--;
   m_availableIndices[m_availableIndicesLength] = index;
   m_availableIndicesLength++;
 }
 
-unsigned short AsyncTimer::setTimeout(void (*callback)(), unsigned long ms) {
+unsigned short AsyncTimer::_setTimeout(Callback& callback, unsigned long ms) {
   return m_newTimerInfo(callback, ms, false);
 }
 
-unsigned short AsyncTimer::setInterval(void (*callback)(), unsigned long ms) {
+unsigned short AsyncTimer::_setInterval(Callback& callback, unsigned long ms) {
   return m_newTimerInfo(callback, ms, true);
 }
 
@@ -115,7 +114,7 @@ void AsyncTimer::handle() {
         m_callsArray[i].timestamp = timestamp;
         m_callsArray[i].callback();
       } else {
-        void (*cb)() = m_callsArray[i].callback;
+        Callback& cb = m_callsArray[i].callback;
         m_cancelEntry(i);
         cb();
       }

--- a/src/AsyncTimer.h
+++ b/src/AsyncTimer.h
@@ -133,12 +133,12 @@ public:
   setup();
   unsigned short setTimeout(Callback::FuncPtr func_ptr, unsigned long ms) {
     Callback func_ptr_cb(func_ptr);
-    _setTimeout(func_ptr_cb, ms);
+    return _setTimeout(func_ptr_cb, ms);
   };
   template <typename T>
   unsigned short setTimeout(T lambda, unsigned long ms) {
     Callback lambda_cb(lambda);
-    _setTimeout(lambda_cb, ms);
+    return _setTimeout(lambda_cb, ms);
   };
 
   unsigned short setInterval(Callback::FuncPtr func_ptr, unsigned long ms) {

--- a/src/AsyncTimer.h
+++ b/src/AsyncTimer.h
@@ -106,15 +106,15 @@ private:
   unsigned short m_generateId();
   unsigned short m_newTimerInfo(Callback& callback, unsigned long ms,
                                 bool indefinite);
+  void m_cancelEntry(unsigned short index);
+  unsigned short _setTimeout(Callback& callback, unsigned long ms);
+  unsigned short _setInterval(Callback& callback, unsigned long ms);
 
   unsigned short m_maxArrayLength;
   unsigned short m_arrayLength = 0;
   m_TimerInfo *m_callsArray;
   unsigned short m_availableIndicesLength;
   unsigned short *m_availableIndices;
-  void m_cancelEntry(unsigned short index);
-  unsigned short _setTimeout(Callback& callback, unsigned long ms);
-  unsigned short _setInterval(Callback& callback, unsigned long ms);
 
 public:
   AsyncTimer(unsigned short arrayLength = 10) {
@@ -125,16 +125,20 @@ public:
     for (unsigned short i = 0; i < m_availableIndicesLength; i++)
       m_availableIndices[i] = i;
   }
+
   ~AsyncTimer() {
     delete[] m_callsArray;
     delete[] m_availableIndices;
   }
+
   [[deprecated("Not needed anymore, will be removed in future versions")]] void
   setup();
+
   unsigned short setTimeout(Callback::FuncPtr func_ptr, unsigned long ms) {
     Callback func_ptr_cb(func_ptr);
     return _setTimeout(func_ptr_cb, ms);
   };
+
   template <typename T>
   unsigned short setTimeout(T lambda, unsigned long ms) {
     Callback lambda_cb(lambda);
@@ -143,12 +147,13 @@ public:
 
   unsigned short setInterval(Callback::FuncPtr func_ptr, unsigned long ms) {
     Callback func_ptr_cb(func_ptr);
-    _setInterval(func_ptr_cb, ms);
+    return _setInterval(func_ptr_cb, ms);
   };
+
   template <typename T>
   unsigned short setInterval(T lambda, unsigned long ms) {
     Callback lambda_cb(lambda);
-    _setInterval(lambda_cb, ms);
+    return _setInterval(lambda_cb, ms);
   };
 
   unsigned long getRemaining(unsigned short id);

--- a/src/AsyncTimer.h
+++ b/src/AsyncTimer.h
@@ -27,9 +27,74 @@
 
 class AsyncTimer {
 private:
+  class Callback {
+  public:
+    using FuncPtr = void(*)();
+
+    Callback() = default;
+    Callback(const Callback&) = delete;
+
+    Callback(FuncPtr funcPtr) :
+        m_isLambda(false), m_funcPtr(funcPtr) {}
+
+    template<typename T>
+    Callback(T lambda) : m_isLambda(true) {
+      m_lambda.data = new T(lambda);
+      m_lambda.execFunc = [](void *data) {
+        (*reinterpret_cast<T*>(data))();
+      };
+      m_lambda.deleteFunc = [](void* data) {
+        delete reinterpret_cast<T*>(data);
+      };
+    }
+
+    ~Callback() {
+      if (m_isLambda && m_lambda.data) {
+        m_lambda.deleteFunc(m_lambda.data);
+      }
+    }
+
+    void operator()() {
+      if (m_isLambda) {
+        return m_lambda.execFunc(m_lambda.data);
+      }
+      return m_funcPtr();
+    }
+
+    Callback& operator=(Callback& other) {
+      if (m_isLambda && m_lambda.data) {
+        m_lambda.deleteFunc(m_lambda.data);
+      }
+      m_isLambda = other.m_isLambda;
+      if (m_isLambda) {
+        m_lambda = other.m_lambda;
+        other.m_lambda.data = nullptr;
+      } else {
+        m_funcPtr = other.m_funcPtr;
+      }
+      return *this;
+    }
+
+  private:
+    using LambdaExecFunc = void(*)(void*);
+    using LambdaDeleteFunc = void(*)(void*);
+
+    struct LambdaStore {
+      void* data;
+      LambdaExecFunc execFunc;
+      LambdaDeleteFunc deleteFunc;
+    };
+
+    bool m_isLambda{false};
+    union {
+      LambdaStore m_lambda;
+      FuncPtr m_funcPtr;
+    };
+  };
+
   struct m_TimerInfo {
     unsigned short id;
-    void (*callback)();
+    Callback callback;
     unsigned long delayByMs;
     unsigned long timestamp;
     bool indefinite;
@@ -39,7 +104,7 @@ private:
   };
 
   unsigned short m_generateId();
-  unsigned short m_newTimerInfo(void (*callback)(), unsigned long ms,
+  unsigned short m_newTimerInfo(Callback& callback, unsigned long ms,
                                 bool indefinite);
 
   unsigned short m_maxArrayLength;
@@ -48,6 +113,8 @@ private:
   unsigned short m_availableIndicesLength;
   unsigned short *m_availableIndices;
   void m_cancelEntry(unsigned short index);
+  unsigned short _setTimeout(Callback& callback, unsigned long ms);
+  unsigned short _setInterval(Callback& callback, unsigned long ms);
 
 public:
   AsyncTimer(unsigned short arrayLength = 10) {
@@ -64,8 +131,26 @@ public:
   }
   [[deprecated("Not needed anymore, will be removed in future versions")]] void
   setup();
-  unsigned short setTimeout(void (*callback)(), unsigned long ms);
-  unsigned short setInterval(void (*callback)(), unsigned long ms);
+  unsigned short setTimeout(Callback::FuncPtr func_ptr, unsigned long ms) {
+    Callback func_ptr_cb(func_ptr);
+    _setTimeout(func_ptr_cb, ms);
+  };
+  template <typename T>
+  unsigned short setTimeout(T lambda, unsigned long ms) {
+    Callback lambda_cb(lambda);
+    _setTimeout(lambda_cb, ms);
+  };
+
+  unsigned short setInterval(Callback::FuncPtr func_ptr, unsigned long ms) {
+    Callback func_ptr_cb(func_ptr);
+    _setInterval(func_ptr_cb, ms);
+  };
+  template <typename T>
+  unsigned short setInterval(T lambda, unsigned long ms) {
+    Callback lambda_cb(lambda);
+    _setInterval(lambda_cb, ms);
+  };
+
   unsigned long getRemaining(unsigned short id);
   void changeDelay(unsigned short id, unsigned long ms);
   void delay(unsigned short id, unsigned long ms);


### PR DESCRIPTION
Thank you for making this library, it's been really helpful for a small project of mine.

This PR adds the ability to capture variables in lambdas used as timer callbacks. For example:

```
AsyncTimer t;

void foo(int v) {
  t.setTimeout([=]() {
    Serial.print("Got value ");
    Serial.println(v, DEC);
  }, 1000);
}
```

Without something like this PR, the above will fail with an error like:
```
Example.ino: In function 'void foo(int)':
Example:12:10: error: no matching function for call to 'AsyncTimer::setTimeout(foo(int)::<lambda()>, int)'
   }, 1000);
          ^
In file included from Example.ino:4:0:
/home/c-jiph/Arduino/libraries/AsyncTimer/src/AsyncTimer.h:77:18: note: candidate: short unsigned int AsyncTimer::setTimeout(AsyncTimer::Callback, long unsigned int)
   unsigned short setTimeout(Callback callback, unsigned long ms);
                  ^~~~~~~~~~
/home/cjiph/Arduino/libraries/AsyncTimer/src/AsyncTimer.h:77:18: note:   no known conversion for argument 1 from 'foo(int)::<lambda()>' to 'AsyncTimer::Callback {aka void (*)()}'
exit status 1
no matching function for call to 'AsyncTimer::setTimeout(foo(int)::<lambda()>, int)'
```

Note this actually fixes the existing example `CancelTimeoutExample.ino` which currently does not compile in master.

I've also included a macro option `LITE_CALLBACK_SUPPORT` which enables the old implementation which will save a small amount of code and data storage for highly constrained projects.